### PR TITLE
Change deprecated unescape() to decodeURIComponent()

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function match (routes, uri, startAt) {
 
     if (captures = uri.match(re)) {
       for (var j = 1, len = captures.length; j < len; ++j) {
-        var value = typeof captures[j] === 'string' ? unescape(captures[j]) : captures[j];
+        var value = typeof captures[j] === 'string' ? decodeURIComponent(captures[j]) : captures[j];
         var key = keys[j - 1];
         if (key) {
           params[key] = value;


### PR DESCRIPTION
Unescape produces invalid results for links using UTF-8 characters, at least in modern browsers. The proposed change to decodeURIComponent() will yield correct results for links escaped by browser. The links manually escaped by using escape() could be an exception to this. Also escape() and unescape() have been deprecated for almost 16 years now.
